### PR TITLE
fixed

### DIFF
--- a/frontend/app/components/NavBar.vue
+++ b/frontend/app/components/NavBar.vue
@@ -6,9 +6,9 @@
         <span style="color: black; font-size: 1rem;">MENU</span>
         <progress class="nes-progress is-pattern" value="100" max="100"></progress>
       </button>
-      <div class="collapse navbar-collapse" id="pongNavbar" style="width:100%; padding: 2vh 2vw 1vh 2vw">
+      <div class="collapse navbar-collapse" id="pongNavbar" style="width:100%; padding: 2vh 2vw 1vh 2vw;">
         <NuxtLink class="nes-btn is-success nav-item" to="/">Home</NuxtLink>
-        <NuxtLink class="nes-btn is-success nav-item" to="/tournament">Tournament</NuxtLink>
+        <NuxtLink v-if="loginStatus" class="nes-btn is-success nav-item" to="/tournament">Tournament</NuxtLink>
         <NuxtLink class="nes-btn is-warning nav-item" to="/leaderboard">Leaderboard</NuxtLink>
         <NuxtLink v-if="loginStatus" class="nes-btn is-error nav-item" to="/userinfopage">UserProfile</NuxtLink>
         <NuxtLink v-if="!loginStatus" class="nes-btn is-error nav-item" to="/login">Login</NuxtLink>
@@ -46,6 +46,10 @@ export default {
 </script>
 
 <style scoped>
+  .nav-item{
+	width: 100%;
+	height: 3.5vh;
+  }
   .nes-btn{
     width: 100%;
     display: flex;

--- a/frontend/app/components/leaderboard/Leaderboard.vue
+++ b/frontend/app/components/leaderboard/Leaderboard.vue
@@ -10,7 +10,7 @@
             <th scope="col">MMR</th>
             <th scope="col">Games<br> Played</th>
             <th scope="col">Win<br> Ratio</th>
-            <th scope="col">User <br> profile</th>
+            <th v-if="loginStatus" scope="col">User <br> profile</th>
           </tr>
         </thead>
         <tbody>
@@ -21,7 +21,7 @@
             <td>{{ user.mmr }}</td>
             <td>{{ user.num_games_played }}</td>
             <td>{{ (user.num_games_played !== 0) ? (( user.num_games_won / user.num_games_played) * 100).toFixed(0) + '%' : '0%' }}</td>
-            <td>
+            <td v-if="loginStatus">
               <router-link :to="{ name: 'userinfopage', query: { username: user.username } }">
                 <button type="button" class="btn nes-btn btn-primary profile-button"><span>View Profile</span></button>
               </router-link>
@@ -33,18 +33,28 @@
 </template>
 
 <script>
+import { isLoggedIn } from '~/store';
 export default {
 	data()
   {
     return { 
       users: [],
-      fetched: false
+      fetched: false,
+      loginStatus: false
     };
   },
 	mounted() 
   {
     this.fetchUsers();
-	},
+
+    watchEffect(() => {
+      if (isLoggedIn.value === 1) {
+        this.loginStatus = true;
+      } else {
+        this.loginStatus = false;
+      }
+    });
+  },
   computed: 
   {
     sortedUsers() 


### PR DESCRIPTION
- Fixed the problem, that the Navbar shows only 2 elements during collapsing (mobile)
- dont show the Tournament in NavBar if not logged in
- dont show the profile-button in Leaderboard if not logged in (because profile pages only work for logged in users)