### PR TITLE
211 navbar font size - the problem with the height

### DIFF
--- a/frontend/app/components/NavBar.vue
+++ b/frontend/app/components/NavBar.vue
@@ -8,11 +8,11 @@
       </button>
       <div class="collapse navbar-collapse" id="pongNavbar" style="width:100%; padding: 2vh 2vw 1vh 2vw; font-size: 1rem;">
         <NuxtLink class="nes-btn nes-btn-style is-success nav-item" to="/">Home</NuxtLink>
-        <NuxtLink v-if="loginStatus" class="nes-btn nes-btn-style is-success nav-item" to="/tournament">Tournament</NuxtLink>
-        <NuxtLink class="nes-btn nes-btn-style is-warning nav-item" to="/leaderboard">Leaderboard</NuxtLink>
-        <NuxtLink v-if="loginStatus" class="nes-btn nes-btn-style is-error nav-item" to="/userinfopage">UserProfile</NuxtLink>
-        <NuxtLink v-if="!loginStatus" class="nes-btn nes-btn-style is-error nav-item" to="/login">Login</NuxtLink>
-        <NuxtLink v-if="loginStatus" class="nes-btn nes-btn-style is-error nav-item" to="/login">Logout</NuxtLink>
+        <NuxtLink v-if="loginStatus" class="nes-btn nes-btn-style is-success nav-item" to="/tournament"><span style="overflow: hidden;">Tournament</span></NuxtLink>
+        <NuxtLink class="nes-btn nes-btn-style is-warning nav-item" to="/leaderboard"><span style="overflow: hidden;">Leaderboard</span></NuxtLink>
+        <NuxtLink v-if="loginStatus" class="nes-btn nes-btn-style is-error nav-item" to="/userinfopage"><span style="overflow: hidden;">UserProfile</span></NuxtLink>
+        <NuxtLink v-if="!loginStatus" class="nes-btn nes-btn-style is-error nav-item" to="/login"><span style="overflow: hidden;">Login</span></NuxtLink>
+        <NuxtLink v-if="loginStatus" class="nes-btn nes-btn-style is-error nav-item" to="/login"><span style="overflow: hidden;">Logout</span></NuxtLink>
       </div>
     </nav>
   </div>
@@ -59,6 +59,7 @@ export default {
     margin-bottom: 1vh;
     margin-right: 0.3vw;
     margin-left: 0.3vw;
+    /* overflow: hidden; */
   }
   .nes-btn-style:hover{
     color: #ffffff;

--- a/frontend/app/components/NavBar.vue
+++ b/frontend/app/components/NavBar.vue
@@ -6,7 +6,7 @@
         <span style="color: black; font-size: 1rem;">MENU</span>
         <progress class="nes-progress is-pattern" value="100" max="100"></progress>
       </button>
-      <div class="collapse navbar-collapse" id="pongNavbar" style="width:100%; padding: 2vh 2vw 1vh 2vw;">
+      <div class="collapse navbar-collapse" id="pongNavbar" style="width:100%; padding: 2vh 2vw 1vh 2vw; font-size: 1rem;">
         <NuxtLink class="nes-btn nes-btn-style is-success nav-item" to="/">Home</NuxtLink>
         <NuxtLink v-if="loginStatus" class="nes-btn nes-btn-style is-success nav-item" to="/tournament">Tournament</NuxtLink>
         <NuxtLink class="nes-btn nes-btn-style is-warning nav-item" to="/leaderboard">Leaderboard</NuxtLink>

--- a/frontend/app/components/NavBar.vue
+++ b/frontend/app/components/NavBar.vue
@@ -7,12 +7,12 @@
         <progress class="nes-progress is-pattern" value="100" max="100"></progress>
       </button>
       <div class="collapse navbar-collapse" id="pongNavbar" style="width:100%; padding: 2vh 2vw 1vh 2vw;">
-        <NuxtLink class="nes-btn is-success nav-item" to="/">Home</NuxtLink>
-        <NuxtLink v-if="loginStatus" class="nes-btn is-success nav-item" to="/tournament">Tournament</NuxtLink>
-        <NuxtLink class="nes-btn is-warning nav-item" to="/leaderboard">Leaderboard</NuxtLink>
-        <NuxtLink v-if="loginStatus" class="nes-btn is-error nav-item" to="/userinfopage">UserProfile</NuxtLink>
-        <NuxtLink v-if="!loginStatus" class="nes-btn is-error nav-item" to="/login">Login</NuxtLink>
-        <NuxtLink v-if="loginStatus" class="nes-btn is-error nav-item" to="/login">Logout</NuxtLink>
+        <NuxtLink class="nes-btn nes-btn-style is-success nav-item" to="/">Home</NuxtLink>
+        <NuxtLink v-if="loginStatus" class="nes-btn nes-btn-style is-success nav-item" to="/tournament">Tournament</NuxtLink>
+        <NuxtLink class="nes-btn nes-btn-style is-warning nav-item" to="/leaderboard">Leaderboard</NuxtLink>
+        <NuxtLink v-if="loginStatus" class="nes-btn nes-btn-style is-error nav-item" to="/userinfopage">UserProfile</NuxtLink>
+        <NuxtLink v-if="!loginStatus" class="nes-btn nes-btn-style is-error nav-item" to="/login">Login</NuxtLink>
+        <NuxtLink v-if="loginStatus" class="nes-btn nes-btn-style is-error nav-item" to="/login">Logout</NuxtLink>
       </div>
     </nav>
   </div>
@@ -50,14 +50,17 @@ export default {
 	width: 100%;
 	height: 3.5vh;
   }
-  .nes-btn{
+  .nes-btn-style{
     width: 100%;
+    height: auto;
     display: flex;
     flex-direction: column;
     color: black;
-    margin-bottom: 1.2vh;
+    margin-bottom: 1vh;
+    margin-right: 0.3vw;
+    margin-left: 0.3vw;
   }
-  .nes-btn:hover{
+  .nes-btn-style:hover{
     color: #ffffff;
   }
 

--- a/frontend/app/components/settings/SettingsPw.vue
+++ b/frontend/app/components/settings/SettingsPw.vue
@@ -13,7 +13,7 @@
 				<label for="password2">Confirm Password:</label>
 				<input type="password" id="password2" name="password2" v-model="password2">
 			</div>
-			<div class="nes-btn is-success nav-item" @click="confirm">Confirm new password
+			<div class="nes-btn nes-btn-pw is-success nav-item" @click="confirm">Confirm new password
 				
 			</div>
 		</div>
@@ -95,13 +95,12 @@
     margin-bottom: 10px;
 }
 
-.nes-btn{
+.nes-btn-pw{
     min-width: 15%;
     color: #000000;
     margin-right: 1%;
-    overflow: hidden;
   }
-  .nes-btn:hover{
+  .nes-btn-pw:hover{
     color: #ffffff;
   }
 

--- a/frontend/app/components/tournament/GameBox.vue
+++ b/frontend/app/components/tournament/GameBox.vue
@@ -12,7 +12,7 @@
         </div>
         
         <div v-if="(match.player1 == this.loggedInUser || match.player2 == this.loggedInUser) && this.loggedInUser != undefined && match.finished == false" class="play-button-container">
-          <button class="nes-btn is-success" @click="sendInvite($event)"> 
+          <button class="nes-btn nes-btn-gamebox is-success" @click="sendInvite($event)"> 
             <span>Play</span>
           </button>
         </div>
@@ -100,7 +100,7 @@ export default {
   align-items: center; /* New property */
 }
 
-.nes-btn {
+.nes-btn-gamebox {
   height: 50%;
   margin: auto;
 }


### PR DESCRIPTION
added different classes to all the files which were changing nes-btn, cause thats globally.
Cared about their height, set to auto cause else a bug, about the first navbar-item filling out the complete height of the menu while in the opening animation.
Added some margin into the navbar items and a scaling font-size.
Added a span around the navbar-items so the wont overflow becuase
Overflow: hidden; kills the nice looking nes-btn style why so ever